### PR TITLE
Remove eval operations from AutoViz_Class.py with getattr

### DIFF
--- a/autoviz/AutoViz_Class.py
+++ b/autoviz/AutoViz_Class.py
@@ -181,7 +181,7 @@ class AutoViz_Class():
             print("Nothing to add Plot not being added")
             pass
         else:
-            eval('self.'+plotname+'["plots"].append(X)')
+            getattr(self, plotname)["plots"].append(X)
 
     def add_subheading(self,plotname,X):
         """
@@ -193,7 +193,7 @@ class AutoViz_Class():
             ### If there is nothing to add, leave it as it is.
             pass
         else:
-            eval('self.'+plotname+'["subheading"].append(X)')
+            getattr(self,plotname)["subheading"].append(X)
 
     def AutoViz(self, filename, sep=',', depVar='', dfte=None, header=0, verbose=0,
                             lowess=False,chart_format='svg',max_rows_analyzed=150000,


### PR DESCRIPTION
I have removed the usage of eval operation from AutoViz_Class's add_subheading and add_plots methods, since its slows down the program performance compared to getattr.