### PR TITLE
Pin `panel~=0.12.6`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ statsmodels
 holoviews==1.14.6
 bokeh==2.4.2
 hvplot==0.7.3
-panel==0.12.6
+panel~=0.12.6
 xgboost
 fsspec==0.8.3
 typing-extensions>=4.1.1


### PR DESCRIPTION
The latest `jninja` release broke compatibility with `panel`, which was fixed in `panel==0.12.7`. This PR relaxes the pin to allow for all panel releases greater or equal to `0.12.6` but less than `0.13`.